### PR TITLE
Added game suspension script

### DIFF
--- a/GTA5PC_Multiscript_by_sadge.ahk
+++ b/GTA5PC_Multiscript_by_sadge.ahk
@@ -52,6 +52,7 @@ SetWorkingDir A_ScriptDir
 #Include %A_ScriptDir%\\subscripts\\IM\\ReturnPersonalVehicle.ahk
 #Include %A_ScriptDir%\\subscripts\\ETC\\UpdateKeys.ahk
 #Include %A_ScriptDir%\\subscripts\\SM\\CareerScreen.ahk
+#Include %A_ScriptDir%\\subscripts\\ETC\\SuspendGame.ahk
 
 ; ------------ Hotkeys trigger workflows -------------------
 currentMode := 0
@@ -92,7 +93,7 @@ $+F10::AssociateChopper()
 $+F11::ReturnPersonalVehicle()
 $+F12::AvengerAutopilot()
 $^+F1::job_list() ; Job List
-;$^+F2:: ; Nicht definiert
+$^+F2::SuspendGame()
 ;$^+F3:: ; Nicht definiert
 ;$^+F4:: ; Nicht definiert
 ;$^+F5:: ; Nicht definiert

--- a/subscripts/ETC/SuspendGame.ahk
+++ b/subscripts/ETC/SuspendGame.ahk
@@ -1,0 +1,62 @@
+; SuspendGame.ahk
+; Suspends notepad.exe for 8 seconds
+; Created for GTA5PC_Multiscript by sadge
+; Requires AutoHotkey v2.0
+
+SuspendGame()
+{
+    ; Get process ID of notepad.exe
+    processName := "GTA5_Enhanced.exe"
+    
+    ; Attempt to find the process
+    processPID := ProcessExist(processName)
+    
+    if (processPID) {
+        ; Display a tooltip to inform user that suspension is happening
+        ToolTip("Suspending " . processName . " for 8 seconds...", 0, 0)
+        
+        ; Suspend the process
+        processSuspend(processPID)
+        
+        ; Wait for 8 seconds
+        Sleep(8000)
+        
+        ; Resume the process
+        processResume(processPID)
+        
+        ; Clear the tooltip
+        ToolTip()
+        
+        ; Show confirmation
+        ToolTip("Process resumed", 0, 0)
+        Sleep(1000)
+        ToolTip()
+    } else {
+        ; Notify if process not found
+        ToolTip(processName . " not found", 0, 0)
+        Sleep(1500)
+        ToolTip()
+    }
+}
+
+; Function to suspend a process by PID
+processSuspend(pid) {
+    h := DllCall("OpenProcess", "uInt", 0x1F0FFF, "Int", 0, "Int", pid)
+    if (h) {
+        DllCall("ntdll.dll\NtSuspendProcess", "Int", h)
+        DllCall("CloseHandle", "Int", h)
+        return true
+    }
+    return false
+}
+
+; Function to resume a suspended process by PID
+processResume(pid) {
+    h := DllCall("OpenProcess", "uInt", 0x1F0FFF, "Int", 0, "Int", pid)
+    if (h) {
+        DllCall("ntdll.dll\NtResumeProcess", "Int", h)
+        DllCall("CloseHandle", "Int", h)
+        return true
+    }
+    return false
+}

--- a/subscripts/ETC/SuspendGame.ahk
+++ b/subscripts/ETC/SuspendGame.ahk
@@ -1,45 +1,24 @@
-; SuspendGame.ahk
-; Suspends notepad.exe for 8 seconds
-; Created for GTA5PC_Multiscript by sadge
-; Requires AutoHotkey v2.0
-
 SuspendGame()
 {
-    ; Get process ID of notepad.exe
     processName := "GTA5_Enhanced.exe"
-    
-    ; Attempt to find the process
     processPID := ProcessExist(processName)
     
     if (processPID) {
-        ; Display a tooltip to inform user that suspension is happening
         ToolTip("Suspending " . processName . " for 8 seconds...", 0, 0)
-        
-        ; Suspend the process
         processSuspend(processPID)
-        
-        ; Wait for 8 seconds
         Sleep(8000)
-        
-        ; Resume the process
         processResume(processPID)
-        
-        ; Clear the tooltip
         ToolTip()
-        
-        ; Show confirmation
         ToolTip("Process resumed", 0, 0)
         Sleep(1000)
         ToolTip()
     } else {
-        ; Notify if process not found
         ToolTip(processName . " not found", 0, 0)
         Sleep(1500)
         ToolTip()
     }
 }
 
-; Function to suspend a process by PID
 processSuspend(pid) {
     h := DllCall("OpenProcess", "uInt", 0x1F0FFF, "Int", 0, "Int", pid)
     if (h) {
@@ -50,7 +29,6 @@ processSuspend(pid) {
     return false
 }
 
-; Function to resume a suspended process by PID
 processResume(pid) {
     h := DllCall("OpenProcess", "uInt", 0x1F0FFF, "Int", 0, "Int", pid)
     if (h) {

--- a/subscripts/ETC/SuspendGame.ahk
+++ b/subscripts/ETC/SuspendGame.ahk
@@ -1,21 +1,50 @@
+global suspensionActive := false
+global suspensionPID := 0
+
 SuspendGame()
 {
+    global suspensionActive, suspensionPID
     processName := "GTA5_Enhanced.exe"
     processPID := ProcessExist(processName)
     
-    if (processPID) {
-        ToolTip("Suspending " . processName . " for 8 seconds...", 0, 0)
-        processSuspend(processPID)
-        Sleep(8000)
-        processResume(processPID)
+    if (suspensionActive) {
+        processResume(suspensionPID)
+        suspensionActive := false
+        suspensionPID := 0
         ToolTip()
-        ToolTip("Process resumed", 0, 0)
+        ToolTip("Suspension cancelled, process resumed", 0, 0)
         Sleep(1000)
         ToolTip()
+        return
+    }
+    
+    if (processPID) {
+        ToolTip("Suspending " . processName . " for 8 seconds...", 0, 0)
+        suspensionActive := true
+        suspensionPID := processPID
+        processSuspend(processPID)
+        
+        SetTimer(ResumeProcess, -8000) 
     } else {
         ToolTip(processName . " not found", 0, 0)
         Sleep(1500)
         ToolTip()
+    }
+}
+
+ResumeProcess()
+{
+    global suspensionActive, suspensionPID
+    
+    if (suspensionActive && suspensionPID) {
+        processResume(suspensionPID)
+        ToolTip()
+        ToolTip("Process resumed", 0, 0)
+        Sleep(1000)
+        ToolTip()
+        
+        suspensionActive := false
+        suspensionPID := 0
     }
 }
 


### PR DESCRIPTION
Added a script to /etc that suspends the GTA_Enhanced.exe process for 8 seconds, can be cancelled by clicking the bind again which I set to ctrl + shift + f2 or ^+f2 since it was the next available bind. 

You could replace the tooltip with a countdown on screen, I didn't because I don't know how to in ahk 2.0. 

You probably know the purpose of suspending the game, but if you don't it disconnects you from p2p servers so everyone including you keeps their sessions, but all other players are removed from your game. Also useful for when you're stuck on loading screens and stuff.

Oh and I assumed this script was intended for Gta Enhanced, you can just change the process name to GTA5.exe for legacy or add that if you want it to work for both versions of the game.